### PR TITLE
fix(tsconfig): Disable exactOptionalPropertyTypes

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -21,7 +21,7 @@
 
         // Stricter Typechecking Options
         "noUncheckedIndexedAccess": true,
-        "exactOptionalPropertyTypes": true,
+        // "exactOptionalPropertyTypes": false,
 
         // Style Options
         // "noImplicitReturns": true,


### PR DESCRIPTION
* toolchain types do not conform to this rule, hence any downstream type usage may get affected